### PR TITLE
add a type definition for the ctest output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 out
+*.vsix
+.vscode-test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "displayName": "ctest-lab",
   "description": "CTest extension for Visual Studio Code",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brobeson/ctest-lab.git"
+  },
   "engines": {
     "vscode": "^1.70.0"
   },


### PR DESCRIPTION
I also cleaned up the ctest run function to handle a promise rejection.
When you await an async function, if that function rejects, then the
rejected promis throws. So you either need to put the await in a
try/catch or use then/catch methods