### PR TITLE
Run tests

### DIFF
--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -8,7 +8,7 @@ set -eu
 #
 # This is tricky. Due to quirks in bash regex matching, the regex must be in a
 # variable, and I can't use quotes in the test.
-inkscape_version=$(inkscape --version)
+inkscape_version=$(inkscape --without-gui --version)
 inkscape_0_regex="^Inkscape 0"
 if [[ ${inkscape_version} =~ ${inkscape_0_regex} ]]
 then

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,23 @@ export function activate(context: vscode.ExtensionContext) {
   controller.refreshHandler = (token: vscode.CancellationToken) =>
     ctest.refresh_tests(controller, log_channel, token);
 
+  const runProfile = controller.createRunProfile(
+    "Run",
+    vscode.TestRunProfileKind.Run,
+    (request, token) => {
+      ctest.run_tests(controller, log_channel, false, request, token);
+    }
+  );
+
+  // TODO figure out debug mode
+  // const debugProfile = controller.createRunProfile(
+  //   "Debug",
+  //   vscode.TestRunProfileKind.Debug,
+  //   (request, token) => {
+  //     ctest.run_tests(controller, log_channel, true, request, token);
+  //   }
+  // );
+
   context.subscriptions.push(controller);
   const discover_tests = () => ctest.refresh_tests(controller, log_channel);
   discover_tests();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
 import * as ctest from "./test_discovery";
+import { run_tests } from "./test_runner";
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -30,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
     "Run",
     vscode.TestRunProfileKind.Run,
     (request, token) => {
-      ctest.run_tests(controller, log_channel, false, request, token);
+      run_tests(controller, log_channel, false, request, token);
     }
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,11 +27,12 @@ export function activate(context: vscode.ExtensionContext) {
   controller.refreshHandler = (token: vscode.CancellationToken) =>
     ctest.refresh_tests(controller, log_channel, token);
 
+  const run_debug = true;
   const runProfile = controller.createRunProfile(
     "Run",
     vscode.TestRunProfileKind.Run,
     (request, token) => {
-      run_tests(controller, log_channel, false, request, token);
+      run_tests(controller, log_channel, !run_debug, request, token);
     }
   );
 
@@ -40,7 +41,7 @@ export function activate(context: vscode.ExtensionContext) {
   //   "Debug",
   //   vscode.TestRunProfileKind.Debug,
   //   (request, token) => {
-  //     ctest.run_tests(controller, log_channel, true, request, token);
+  //     ctest.run_tests(controller, log_channel, run_debug, request, token);
   //   }
   // );
 

--- a/src/extension_helpers.ts
+++ b/src/extension_helpers.ts
@@ -1,0 +1,22 @@
+import * as vscode from "vscode";
+
+export function get_build_directory(): string {
+  let build_directory: string = "";
+  let config = vscode.workspace.getConfiguration("cmake");
+  if (config.has("buildDirectory")) {
+    build_directory = config.get("buildDirectory") as string;
+  } else {
+    config = vscode.workspace.getConfiguration("ctest-lab");
+    build_directory = config.get("buildDirectory") as string;
+  }
+  return replace_code_variables(build_directory);
+}
+
+function replace_code_variables(path: string): string {
+  if (vscode.workspace.workspaceFolders) {
+    const workspaceFolder: string =
+      vscode.workspace.workspaceFolders[0].uri.fsPath;
+    return path.replace("${workspaceFolder}", workspaceFolder);
+  }
+  return path;
+}

--- a/src/test/package_test.sh
+++ b/src/test/package_test.sh
@@ -9,8 +9,11 @@ expected_files="[Content_Types].xml
 extension/CHANGELOG.md
 extension/images/logo.png
 extension/LICENSE.txt
+extension/out/extension_helpers.js
 extension/out/extension.js
+extension/out/test_details.js
 extension/out/test_discovery.js
+extension/out/test_runner.js
 extension/package.json
 extension/README.md
 extension.vsixmanifest"

--- a/src/test_details.ts
+++ b/src/test_details.ts
@@ -1,0 +1,7 @@
+import * as vscode from "vscode";
+
+type TestDetails = {
+  command: string[];
+};
+
+export const test_details = new WeakMap<vscode.TestItem, TestDetails>();

--- a/src/test_discovery.ts
+++ b/src/test_discovery.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 import { spawn } from "child_process";
+import { get_build_directory } from "./extension_helpers";
+import { test_details } from "./test_details";
 
 // https://cmake.org/cmake/help/latest/manual/ctest.1.html#show-as-json-object-model
 type CTestConfiguration = {
@@ -26,12 +28,6 @@ type CTestConfiguration = {
     properties: { name: string; value: any }[];
   }[];
 };
-
-type TestDetails = {
-  command: string[];
-};
-
-const test_details = new WeakMap<vscode.TestItem, TestDetails>();
 
 /**
  * Discover tests and populate the test controller with test items.
@@ -116,116 +112,6 @@ function run_ctest_show_only_json(
       reject({ message: "Failed to run ctest" });
     }
   });
-}
-
-async function run_test(
-  test: vscode.TestItem,
-  signal: AbortSignal,
-  log: vscode.OutputChannel
-): Promise<{ stdout: string; stderr: string; code: number | null }> {
-  return new Promise((resolve, reject) => {
-    const test_detail = test_details.get(test)!;
-    const command = test_detail.command[0];
-    const args = test_detail.command.slice(1);
-    const process = spawn(command, args, {
-      signal,
-      cwd: get_build_directory(),
-    });
-
-    let stdout =
-      command + " " + args.map((val) => JSON.stringify(val)).join(" ") + "\n";
-    let stderr = "";
-    if (process.pid) {
-      process.stdout.on("data", (data) => (stdout += data.toString()));
-      process.stderr.on("data", (data) => (stderr += data.toString()));
-      process.on("close", (code) => resolve({ stdout, stderr, code }));
-      process.on("error", (err) => reject(err));
-    } else {
-      reject({ message: `Failed to run test ${command} ${args.join(" ")}` });
-    }
-  });
-}
-
-/**
- * The run handler executes each requested test and reports the output
- * or errors to the VS Code Testing API via the TestRun interface. Tests
- * may be cancelled via the CancellationToken.
- * @param test_controller VS Code test controller
- * @param log VS Code extension output channel
- * @param shouldDebug Should tests run in debug
- * @param request VS Code test run request
- * @param token VS Code cancellation token
- */
-export async function run_tests(
-  test_controller: vscode.TestController,
-  log: vscode.OutputChannel,
-  shouldDebug: boolean,
-  request: vscode.TestRunRequest,
-  token: vscode.CancellationToken
-) {
-  const abort_controller = new AbortController();
-  const { signal } = abort_controller;
-  token?.onCancellationRequested(() => abort_controller.abort());
-
-  const run = test_controller.createTestRun(request);
-  const queue: vscode.TestItem[] = [];
-
-  if (request.include) {
-    request.include.forEach((test) => queue.push(test));
-  } else {
-    test_controller.items.forEach((test) => queue.push(test));
-  }
-
-  while (queue.length > 0 && !token.isCancellationRequested) {
-    const test = queue.pop()!;
-
-    // Skip tests the user asked to exclude
-    if (request.exclude?.includes(test)) {
-      continue;
-    }
-
-    const start = Date.now();
-    try {
-      const { stdout, stderr, code } = await run_test(test, signal, log);
-      // test output is in a terminal so lines must be wrapped
-      // using CRLF (\r\n), not just LF (\n)
-      run.appendOutput(stdout.replaceAll("\r", "").replaceAll("\n", "\r\n"));
-
-      if (code === 0) {
-        run.passed(test, Date.now() - start);
-      } else {
-        const message = new vscode.TestMessage(stderr);
-        run.errored(test, message, Date.now() - start);
-      }
-    } catch (e: any) {
-      run.failed(test, new vscode.TestMessage(e.message), Date.now() - start);
-    }
-
-    test.children.forEach((test) => queue.push(test));
-  }
-
-  run.end();
-}
-
-function get_build_directory(): string {
-  let build_directory: string = "";
-  let config = vscode.workspace.getConfiguration("cmake");
-  if (config.has("buildDirectory")) {
-    build_directory = config.get("buildDirectory") as string;
-  } else {
-    config = vscode.workspace.getConfiguration("ctest-lab");
-    build_directory = config.get("buildDirectory") as string;
-  }
-  return replace_code_variables(build_directory);
-}
-
-function replace_code_variables(path: string): string {
-  if (vscode.workspace.workspaceFolders) {
-    const workspaceFolder: string =
-      vscode.workspace.workspaceFolders[0].uri.fsPath;
-    return path.replace("${workspaceFolder}", workspaceFolder);
-  }
-  return path;
 }
 
 function get_test_tags(test_properties: any): vscode.TestTag[] {

--- a/src/test_discovery.ts
+++ b/src/test_discovery.ts
@@ -27,6 +27,12 @@ export type CTestConfiguration = {
   }[];
 };
 
+type TestDetails = {
+  command: string[];
+};
+
+const test_details = new WeakMap<vscode.TestItem, TestDetails>();
+
 /**
  * Discover tests and populate the test controller with test items.
  * When called multiple times, it will replace all previous test items
@@ -77,6 +83,8 @@ export async function refresh_tests(
           test_item.tags = get_test_tags(test.properties);
           test_item.description = get_test_description(test.properties);
           tests.push(test_item);
+
+          test_details.set(test_item, { command: test.command });
         }
         test_controller.items.replace(tests);
         log.appendLine(`found ${test_controller.items.size} tests`);
@@ -100,21 +108,103 @@ function run_ctest_show_only_json(
     let stdout = "";
     let stderr = "";
     if (process.pid) {
-      process.stdout.on("data", (data) => {
-        data = data.toString();
-        stdout += data;
-      });
-      process.stderr.on("data", (data) => {
-        stderr += data.toString();
-      });
-      process.on("close", (code) => {
-        resolve({ stdout, stderr, code });
-      });
+      process.stdout.on("data", (data) => (stdout += data.toString()));
+      process.stderr.on("data", (data) => (stderr += data.toString()));
+      process.on("close", (code) => resolve({ stdout, stderr, code }));
       process.on("error", (err) => reject(err));
     } else {
       reject({ message: "Failed to run ctest" });
     }
   });
+}
+
+async function run_test(
+  test: vscode.TestItem,
+  signal: AbortSignal,
+  log: vscode.OutputChannel
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const test_detail = test_details.get(test)!;
+    const command = test_detail.command[0];
+    const args = test_detail.command.slice(1);
+    const process = spawn(command, args, {
+      signal,
+      cwd: get_build_directory(),
+    });
+
+    let stdout =
+      command + " " + args.map((val) => JSON.stringify(val)).join(" ") + "\n";
+    let stderr = "";
+    if (process.pid) {
+      process.stdout.on("data", (data) => (stdout += data.toString()));
+      process.stderr.on("data", (data) => (stderr += data.toString()));
+      process.on("close", (code) => resolve({ stdout, stderr, code }));
+      process.on("error", (err) => reject(err));
+    } else {
+      reject({ message: `Failed to run test ${command} ${args.join(" ")}` });
+    }
+  });
+}
+
+/**
+ * The run handler executes each requested test and reports the output
+ * or errors to the VS Code Testing API via the TestRun interface. Tests
+ * may be cancelled via the CancellationToken.
+ * @param test_controller VS Code test controller
+ * @param log VS Code extension output channel
+ * @param shouldDebug Should tests run in debug
+ * @param request VS Code test run request
+ * @param token VS Code cancellation token
+ */
+export async function run_tests(
+  test_controller: vscode.TestController,
+  log: vscode.OutputChannel,
+  shouldDebug: boolean,
+  request: vscode.TestRunRequest,
+  token: vscode.CancellationToken
+) {
+  const abort_controller = new AbortController();
+  const { signal } = abort_controller;
+  token?.onCancellationRequested(() => abort_controller.abort());
+
+  const run = test_controller.createTestRun(request);
+  const queue: vscode.TestItem[] = [];
+
+  if (request.include) {
+    request.include.forEach((test) => queue.push(test));
+  } else {
+    test_controller.items.forEach((test) => queue.push(test));
+  }
+
+  while (queue.length > 0 && !token.isCancellationRequested) {
+    const test = queue.pop()!;
+
+    // Skip tests the user asked to exclude
+    if (request.exclude?.includes(test)) {
+      continue;
+    }
+
+    const start = Date.now();
+    try {
+      const { stdout, stderr, code } = await run_test(test, signal, log);
+      // test output is in a terminal so lines must be wrapped
+      // using CRLF (\r\n), not just LF (\n)
+      run.appendOutput(stdout.replaceAll("\r", "").replaceAll("\n", "\r\n"));
+
+      if (code === 0) {
+        run.passed(test, Date.now() - start);
+      } else {
+        const message = new vscode.TestMessage(stderr);
+        run.errored(test, message, Date.now() - start);
+      }
+    } catch (e: any) {
+      run.failed(test, new vscode.TestMessage(e.message), Date.now() - start);
+    }
+
+    test.children.forEach((test) => queue.push(test));
+  }
+
+  run.end();
 }
 
 function get_build_directory(): string {

--- a/src/test_discovery.ts
+++ b/src/test_discovery.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { spawn } from "child_process";
 
 // https://cmake.org/cmake/help/latest/manual/ctest.1.html#show-as-json-object-model
-export type CTestConfiguration = {
+type CTestConfiguration = {
   kind: "ctestInfo";
   version: {
     major: number;

--- a/src/test_runner.ts
+++ b/src/test_runner.ts
@@ -53,16 +53,16 @@ export async function run_tests(
   token?.onCancellationRequested(() => abort_controller.abort());
 
   const run = test_controller.createTestRun(request);
-  const queue: vscode.TestItem[] = [];
+  const test_queue: vscode.TestItem[] = [];
 
   if (request.include) {
-    request.include.forEach((test) => queue.push(test));
+    request.include.forEach((test) => test_queue.push(test));
   } else {
-    test_controller.items.forEach((test) => queue.push(test));
+    test_controller.items.forEach((test) => test_queue.push(test));
   }
 
-  while (queue.length > 0 && !token.isCancellationRequested) {
-    const test = queue.pop()!;
+  while (test_queue.length > 0 && !token.isCancellationRequested) {
+    const test = test_queue.pop()!;
 
     // Skip tests the user asked to exclude
     if (request.exclude?.includes(test)) {
@@ -86,7 +86,7 @@ export async function run_tests(
       run.failed(test, new vscode.TestMessage(e.message), Date.now() - start);
     }
 
-    test.children.forEach((test) => queue.push(test));
+    test.children.forEach((test) => test_queue.push(test));
   }
 
   run.end();

--- a/src/test_runner.ts
+++ b/src/test_runner.ts
@@ -1,0 +1,93 @@
+import * as vscode from "vscode";
+import { spawn } from "child_process";
+import { get_build_directory } from "./extension_helpers";
+import { test_details } from "./test_details";
+
+async function run_test(
+  test: vscode.TestItem,
+  signal: AbortSignal,
+  log: vscode.OutputChannel
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const test_detail = test_details.get(test)!;
+    const command = test_detail.command[0];
+    const args = test_detail.command.slice(1);
+    const process = spawn(command, args, {
+      signal,
+      cwd: get_build_directory(),
+    });
+
+    let stdout =
+      command + " " + args.map((val) => JSON.stringify(val)).join(" ") + "\n";
+    let stderr = "";
+    if (process.pid) {
+      process.stdout.on("data", (data) => (stdout += data.toString()));
+      process.stderr.on("data", (data) => (stderr += data.toString()));
+      process.on("close", (code) => resolve({ stdout, stderr, code }));
+      process.on("error", (err) => reject(err));
+    } else {
+      reject({ message: `Failed to run test ${command} ${args.join(" ")}` });
+    }
+  });
+}
+
+/**
+ * The run handler executes each requested test and reports the output
+ * or errors to the VS Code Testing API via the TestRun interface. Tests
+ * may be cancelled via the CancellationToken.
+ * @param test_controller VS Code test controller
+ * @param log VS Code extension output channel
+ * @param shouldDebug Should tests run in debug
+ * @param request VS Code test run request
+ * @param token VS Code cancellation token
+ */
+export async function run_tests(
+  test_controller: vscode.TestController,
+  log: vscode.OutputChannel,
+  shouldDebug: boolean,
+  request: vscode.TestRunRequest,
+  token: vscode.CancellationToken
+) {
+  const abort_controller = new AbortController();
+  const { signal } = abort_controller;
+  token?.onCancellationRequested(() => abort_controller.abort());
+
+  const run = test_controller.createTestRun(request);
+  const queue: vscode.TestItem[] = [];
+
+  if (request.include) {
+    request.include.forEach((test) => queue.push(test));
+  } else {
+    test_controller.items.forEach((test) => queue.push(test));
+  }
+
+  while (queue.length > 0 && !token.isCancellationRequested) {
+    const test = queue.pop()!;
+
+    // Skip tests the user asked to exclude
+    if (request.exclude?.includes(test)) {
+      continue;
+    }
+
+    const start = Date.now();
+    try {
+      const { stdout, stderr, code } = await run_test(test, signal, log);
+      // test output is in a terminal so lines must be wrapped
+      // using CRLF (\r\n), not just LF (\n)
+      run.appendOutput(stdout.replaceAll("\r", "").replaceAll("\n", "\r\n"));
+
+      if (code === 0) {
+        run.passed(test, Date.now() - start);
+      } else {
+        const message = new vscode.TestMessage(stderr);
+        run.errored(test, message, Date.now() - start);
+      }
+    } catch (e: any) {
+      run.failed(test, new vscode.TestMessage(e.message), Date.now() - start);
+    }
+
+    test.children.forEach((test) => queue.push(test));
+  }
+
+  run.end();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "ES2020",
     "outDir": "out",
-    "lib": ["ES2020"],
+    "lib": ["ES2021"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */


### PR DESCRIPTION
extra information needed to run tests like the command to execute is
stored in a weak map. This data structure stores keys as weak references
which do not keep objects from being garbage collected.

These are all the example tests in the catch2 repo
![image](https://user-images.githubusercontent.com/19827319/187050299-a26d915b-85cd-47ba-beff-a3d65bd029f2.png)
